### PR TITLE
Update Wixoss_WXDi-D03.cod

### DIFF
--- a/decks/Wixoss_WXDi-D03.cod
+++ b/decks/Wixoss_WXDi-D03.cod
@@ -22,9 +22,9 @@
         <card number="1" name="Akino, Advancing Towards the Future"/>
         <card number="1" name="Rei, Soaring Towards Tomorrow"/>
         <card number="1" name="Glory Grow"/>
-        <card number="1" name="Akino∗Rock"/>
-        <card number="1" name="Akino∗Paper"/>
-        <card number="1" name="Rei∗One Cut"/>
-        <card number="1" name="Rei∗Selfless Cut"/>
+        <card number="1" name="Akino＊Rock"/>
+        <card number="1" name="Akino＊Paper"/>
+        <card number="1" name="Rei＊One Cut"/>
+        <card number="1" name="Rei＊Selfless Cut"/>
     </zone>
 </cockatrice_deck>


### PR DESCRIPTION
The Asterisk on the Akino and Rei cards are using the standard Asterisk * instead of the Japanese ＊

This causes the deck to not load the assist cards when starting a game. They display fine from the Deck Editor, except list in the Sideboard under "unknown" instead of LRIG|Assist
And then in-game, the cards are blank