### PR TITLE
Update Wixoss_WXDi-D03.cod

### DIFF
--- a/decks/Wixoss_WXDi-D03.cod
+++ b/decks/Wixoss_WXDi-D03.cod
@@ -12,7 +12,7 @@
         <card number="4" name="Adamasphere, Natural Stone"/>
         <card number="4" name="Roaring Fireball"/>
         <card number="4" name="Bronze, Natural Stone"/>
-        <card number="4" name="Silvarna, Natural Stone"/>
+        <card number="4" name="Silverna, Natural Stone"/>
     </zone>
     <zone name="side">
         <card number="1" name="Hirana, One Step Towards the Fragment"/>


### PR DESCRIPTION
Typo is preventing this deck from displaying a card. Shows up under Unknown in deck builder, and card is empty in-game.